### PR TITLE
fix(aria2/Dockerfile): Connot found entrypoint.sh in alpine.

### DIFF
--- a/aria2/Dockerfile
+++ b/aria2/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.19.1
 
 RUN apk update && apk add --no-cache aria2
 
-ADD entrypoint.sh /
-ADD aria2.conf /
+ADD ./entrypoint.sh /
+ADD ./aria2.conf /
 
 EXPOSE 6800
 


### PR DESCRIPTION
Fixed the issue of not being able to find `entrypoint.sh` when building the image in the root directory.