### PR TITLE
added support of kubernetes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ BASE_DOMAIN=local.homeinfra.org
 
 # for aria2 and mirrors
 RPC_SECRET=changeit
+SSL_SELF_SIGNED=true
 
 # in case any other service need the uppercase or lowercase one
 # aria2 need the lowercase one, FYI https://aria2.github.io/manual/en/html/aria2c.html#environment

--- a/aria2/Dockerfile
+++ b/aria2/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.19.1
 
 RUN apk update && apk add --no-cache aria2
 
+RUN mkdir /data
+
 ADD ./entrypoint.sh /
 ADD ./aria2.conf /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,9 @@ services:
     build:
       context: ./src
     volumes:
-      - ./src/:/app
       - ./data/cache:/app/cache
     env_file:
       - .env
-    environment:
-      - SSL_SELF_SIGNED=true
     networks:
       - app
     restart: unless-stopped
@@ -23,7 +20,6 @@ services:
     image: lightmirrors/aria2
     build: ./aria2
     volumes:
-      - ./aria2/aria2.conf:/aria2.conf
       - ./data/cache:/app/cache
       - ./data/aria2:/data/
     networks:

--- a/kubernetes/aria2-deployment.yaml
+++ b/kubernetes/aria2-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lightmirrors-aria2
+  namespace: lightmirrors
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: lightmirrors-aria2
+  template:
+    metadata:
+      labels:
+        app: lightmirrors-aria2
+    spec:
+      containers:
+        - name: aria2
+          image: lightmirrors/aria2:v0.0.1 # Not on DockerHub. You need to build and post image yourself
+          ports:
+            - name: http
+              containerPort: 6800
+          env:
+            - name: no_proxy
+              value: "lightmirrors-mirror.lightmirrors"
+            - name: RPC_SECRET
+              value: changeMe
+          volumeMounts:
+            - name: cache-volume
+              mountPath: /app/cache
+      volumes:
+        - name: cache-volume
+          persistentVolumeClaim:
+            claimName: lightmirrors-pvc

--- a/kubernetes/mirror-deployment.yaml
+++ b/kubernetes/mirror-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lightmirrors-mirror
+  namespace: lightmirrors
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: lightmirrors-mirror
+  template:
+    metadata:
+      labels:
+        app: lightmirrors-mirror
+    spec:
+      containers:
+        - name: mirrors
+          image: lightmirrors/mirrors:v0.0.2 # Not on DockerHub. You need to build and post image yourself
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          env:
+            - name: SSL_SELF_SIGNED
+              value: "true"
+            - name: EXTERNAL_HOST_ARIA2
+              value: "lightmirrors-aria2"
+            - name: BASE_DOMAIN
+              value: "lightmirrors"
+            - name: RPC_SECRET
+              value: changeMe
+            - name: K8S_SERVICE_NAME
+              value: "-lightmirrors"
+            - name: ARIA2_RPC_URL
+              value: "http://lightmirrors-aria2:6800/jsonrpc"
+          volumeMounts:
+            - name: cache-volume
+              mountPath: /app/cache
+      volumes:
+        - name: cache-volume
+          persistentVolumeClaim:
+            claimName: lightmirrors-pvc

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lightmirrors
+  

--- a/kubernetes/pvc.yaml
+++ b/kubernetes/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lightmirrors-pvc
+  namespace: lightmirrors
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 90Gi
+  storageClassName: nfs-sc

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pypi-lightmirrors
+  namespace: lightmirrors
+spec:
+  selector:
+    app: lightmirrors-mirror
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lightmirrors-aria2
+  namespace: lightmirrors
+spec:
+  selector:
+    app: lightmirrors-aria2
+  ports:
+    - protocol: TCP
+      port: 6800
+      targetPort: 6800
+  type: ClusterIP

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ ADD . /app
 
 WORKDIR /app
 
-EXPOSE 8080
+EXPOSE 80 443
 
 CMD ["python", "mirrorsrun/server.py"]
 

--- a/src/mirrorsrun/config.py
+++ b/src/mirrorsrun/config.py
@@ -3,13 +3,14 @@ import os
 ARIA2_RPC_URL = os.environ.get("ARIA2_RPC_URL", "http://aria2:6800/jsonrpc")
 RPC_SECRET = os.environ.get("RPC_SECRET", "")
 BASE_DOMAIN = os.environ.get("BASE_DOMAIN", "local.homeinfra.org")
+K8S_SERVICE_NAME = os.environ.get("K8S_SERVICE_NAME", "")
 
 SCHEME = "https"
 
 SSL_SELF_SIGNED = os.environ.get("SSL_SELF_SIGNED", "true") == "true"
 
 CACHE_DIR = os.environ.get("CACHE_DIR", "/app/cache/")
-EXTERNAL_HOST_ARIA2 = f"aria2.{BASE_DOMAIN}"
+EXTERNAL_HOST_ARIA2 = os.environ.get("EXTERNAL_HOST_ARIA2", f"aria2.{BASE_DOMAIN}")
 EXTERNAL_URL_ARIA2 = f"{SCHEME}://{EXTERNAL_HOST_ARIA2}/aria2/index.html"
 
 BASE_URL_PYTORCH = os.environ.get("BASE_URL_PYTORCH", "https://download.pytorch.org")

--- a/src/mirrorsrun/server.py
+++ b/src/mirrorsrun/server.py
@@ -22,6 +22,7 @@ from mirrorsrun.config import (
     EXTERNAL_URL_ARIA2,
     EXTERNAL_HOST_ARIA2,
     SCHEME, SSL_SELF_SIGNED,
+    K8S_SERVICE_NAME,
 )
 
 from mirrorsrun.sites.npm import npm
@@ -32,16 +33,16 @@ from mirrorsrun.sites.common import common
 from mirrorsrun.sites.goproxy import goproxy
 
 subdomain_mapping = {
-    "mirrors": common,
-    "pypi": pypi,
-    "torch": torch,
-    "npm": npm,
-    "docker": dockerhub,
-    "k8s": k8s,
-    "ghcr": ghcr,
-    "quay": quay,
-    "nvcr": nvcr,
-    "goproxy": goproxy,
+    f"mirrors{K8S_SERVICE_NAME}": common,
+    f"pypi{K8S_SERVICE_NAME}": pypi,
+    f"torch{K8S_SERVICE_NAME}": torch,
+    f"npm{K8S_SERVICE_NAME}": npm,
+    f"docker{K8S_SERVICE_NAME}": dockerhub,
+    f"k8s{K8S_SERVICE_NAME}": k8s,
+    f"ghcr{K8S_SERVICE_NAME}": ghcr,
+    f"quay{K8S_SERVICE_NAME}": quay,
+    f"nvcr{K8S_SERVICE_NAME}": nvcr,
+    f"goproxy{K8S_SERVICE_NAME}": goproxy,
 }
 
 logging.basicConfig(


### PR DESCRIPTION
Fixes:
 - As there is an .env file, so SSL_SELF_SIGNED moved there, so there is now need to set it in docker-compose
 - "/app" folder is already inside mirrors docker image, so removed mounting to local folder in docker-compose. Also "aria2.conf" already inside aria2 image.
 - Add a /data dir inside aria2 image, to be able not to mount volume for sessions. If you still want to mount, it will work fine.
 
Features:
 - Updated subdomain_mapping, because there is really hard to implement wildcard DNS in k8s. Now you should create a separate k8s Service for each instrument in format of <instrument_name>-<K8S_SERVICE_NAME> where <instrument_name> is one from ["mirrors",  "pypi"i,  "torch", "npm", "docker", "k8s", "ghcr", "quay", "nvcr", "goproxy"] and <K8S_SERVICE_NAME> is some name that should be set in ENV var.
 - Added k8s manifests examples which serves pypi server caching with K8S_SERVICE_NAME = "-lightmirrors" and so Service name is pypi-lightmirrors

Tests:
 - Tested with 2 replicas of each deployments for pipy packages download. Other instruments not tested yet.